### PR TITLE
catch PathTooLongException exceptions (crash)

### DIFF
--- a/DiskUsageAnalyzer/FolderAnalyzer.cs
+++ b/DiskUsageAnalyzer/FolderAnalyzer.cs
@@ -64,6 +64,10 @@ namespace DiskUsageAnalyzer
 				//If we cannot traverse further because of the directory access rules then stop.
 				return;
 			}
+			catch (PathTooLongException)
+			{
+
+			}
 		}
 
         //Calculates the size in bytes of a folder.


### PR DESCRIPTION
npm is particular bad at making long paths
